### PR TITLE
Add option to fail on errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-php_codesniffer (0.1.5)
+    danger-php_codesniffer (0.1.6)
       danger-plugin-api (~> 1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,26 +14,40 @@ $ gem install danger-php_codesniffer
 
 Detect your PHP violations of a defined coding standard. The plugin will post a comment on PR/MR on your Github or Gitlab project.
 
-Dangerfile:
+Add this to your Dangerfile to run CodeSniffer:
 
 ```
 php_codesniffer.exec
 ```
 
-Ignore file/path and use specific coding standard:
+---
+
+You can modify how the plugin behaves by adding one or more of the following options before the `php_codesniffer.exec` call:
+
+Ignore file/path:
 
 ```
 php_codesniffer.ignore = "./vendor"
+```
+
+Use specific coding standard:
+
+```
 php_codesniffer.standard = "CodeIgniter"
-php_codesniffer.exec
 ```
 
 Only check new and modified file:
 
 ```
 php_codesniffer.filtering = true
-php_codesniffer.exec
 ```
+
+Fail the pipeline if CodeSniffer reports any errors (you also have to run Danger with the `--fail-on-errors` flag set to true):
+
+```
+php_codesniffer.fail_on_error = true
+```
+
 
 ## Development
 

--- a/lib/php_codesniffer/gem_version.rb
+++ b/lib/php_codesniffer/gem_version.rb
@@ -1,3 +1,3 @@
 module PhpCodesniffer
-  VERSION = "0.1.5".freeze
+  VERSION = "0.1.6".freeze
 end

--- a/lib/php_codesniffer/plugin.rb
+++ b/lib/php_codesniffer/plugin.rb
@@ -30,6 +30,12 @@ module Danger
     # @return [Boolean]
     attr_accessor :filtering
 
+    # An attribute for failing on errors
+    # In case phpcs finds errors, Danger will also fail
+    # This allows failing pipelines using the `--fail-on-errors` flag in Danger
+    # @return [Boolean]
+    attr_accessor :fail_on_error
+
     # Execute and process phpcs CLL's result.
     #
     # @return [void]
@@ -63,6 +69,9 @@ module Danger
       markdown "# PHP_CodeSniffer report"
       markdown generate_summary_markdown summary
       markdown report
+      if fail_on_error && summary["errors"] > 0
+        fail "There are #{summary["errors"]} errors that need to be resolved."
+      end
     end
 
     private


### PR DESCRIPTION
I need our pipeline to fail in case of errors from CodeSniffer, so no one could accidentally merge code that does not fit PSR-2. Currently, the plugin only reports the errors, but Danger does not fail if there are any.

I've added a new option called `fail_on_error`. After the markdown report is sent, I check if the option is enabled and if there have been any errors and tell Danger to fail the build in that case. (Will only fail in case the `--fail-on-errors` setting for Danger is used, of course.) I documented the new option in the usage section of the Readme and also reformatted it slightly to make it more readable.

I'm afraid I am not 100% certain if this actually works, because I haven't found any proper documention for writing Danger plugins. I've looked into another plugin to see how they fail builds in case of errors. For example here: https://github.com/dblock/danger-changelog/blob/5fa7295a3fc4a1b749818333c9e3c5bbd7683812/lib/changelog/plugin.rb#L91

I also don't have much experience with Ruby and Rubygems, so I just copied what you did on the last version update in order to hopefully save you some work. :) But please let me know how I could have done anything better, I'm happy to learn more in this area!