### PR TITLE
Don't output report if there are no errors/warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-php_codesniffer (0.1.6)
+    danger-php_codesniffer (0.1.7)
       danger-plugin-api (~> 1.0)
 
 GEM

--- a/lib/php_codesniffer/gem_version.rb
+++ b/lib/php_codesniffer/gem_version.rb
@@ -1,3 +1,3 @@
 module PhpCodesniffer
-  VERSION = "0.1.6".freeze
+  VERSION = "0.1.7".freeze
 end

--- a/lib/php_codesniffer/plugin.rb
+++ b/lib/php_codesniffer/plugin.rb
@@ -68,9 +68,12 @@ module Danger
           end
       end
 
-      markdown "# PHP_CodeSniffer report"
-      markdown generate_summary_markdown summary
-      markdown report
+      if (summary["errors"] + summary["warnings"] + summary["fixable"]) > 0
+        markdown "# PHP_CodeSniffer report"
+        markdown generate_summary_markdown summary
+        markdown report
+      end
+      
       if fail_on_error && summary["errors"] > 0
         fail "There are #{summary["errors"]} errors that need to be resolved."
       end

--- a/lib/php_codesniffer/plugin.rb
+++ b/lib/php_codesniffer/plugin.rb
@@ -62,7 +62,9 @@ module Danger
             summary["warnings"] += totals.fetch("warnings")
             summary["fixable"] += totals.fetch("fixable")
 
-            report.push(generate_report result)
+            if (totals["errors"] + totals.fetch("warnings") + totals.fetch("fixable")) > 0
+              report.push(generate_report result)
+            end
           end
       end
 


### PR DESCRIPTION
I'm back! 🙃

This is a small quality-of-life improvement in two similar parts.

---

**First**: Currently the report will always be printed, regardless of what the actual output from phpcs was. This often results in reports like this on our project:

![image](https://user-images.githubusercontent.com/13483728/73285491-632ee780-41f6-11ea-9f28-bee35c7bff04.png)

I changed this in commit 09342aa.

---

**Second**: When using the `filtering` option, each file will always be included in the report – even if it had no errors. Here is a good example of how that looks:

![image](https://user-images.githubusercontent.com/13483728/73285713-b7d26280-41f6-11ea-8f5e-7108aa1a1f36.png)

This is annoying because you have to open all three files manually to find out which file is the one that actually has a problem. Commit d42a05f should stop files that have zero problems from being added to the report.


---

Again, I tried to help with updating the Gem version to the best of my knowledge. As this PR doesn't add new functionality, I didn't change the documentation/readme. Let me know if you have any remarks or suggestions! 🙂