### PR TITLE
Allow ignoring warnings or fixables

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-php_codesniffer (0.1.7)
+    danger-php_codesniffer (0.1.8)
       danger-plugin-api (~> 1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Fail the pipeline if CodeSniffer reports any errors (you also have to run Danger
 php_codesniffer.fail_on_error = true
 ```
 
+Ignore warnings and/or fixables in the Danger output:
+
+```
+php_codesniffer.ignore_warnings = true
+php_codesniffer.ignore_fixables = true
+```
 
 ## Development
 

--- a/lib/php_codesniffer/gem_version.rb
+++ b/lib/php_codesniffer/gem_version.rb
@@ -1,3 +1,3 @@
 module PhpCodesniffer
-  VERSION = "0.1.7".freeze
+  VERSION = "0.1.8".freeze
 end


### PR DESCRIPTION
We would like to have a way to ignore warnings and fixables in the Danger output. :)

The  most common warning we get in our MRs is about long lines. We do not want to see it there, because it is not a blocker and it usually is reported very often for old/existing code. However, we do not want to disable the warning via `phpcs.xml`, because we still want to see the warning in our IDEs.

So my proposed solution would be to add two new configuration options, `ignore_warnings` and `ignore_fixables`, which then suppress the output of warnings and fixables in the Danger report.

I'm not 100% happy with the solution because there is a bit of duplicated code, but I could not think of a better solution without changing much more. I hope that the variable names are clear and obvious and I think the code is still fairly understandable. But I'd be happy to add some additional comments if you feel they are necessary. And of course I'm very open if you have a completely different idea on how to solve it!

In case you are okay with the changes, I've prepared documention and version info as usual. :)