### PR TITLE
Exclude renamed-from files from filtered list

### DIFF
--- a/lib/php_codesniffer/plugin.rb
+++ b/lib/php_codesniffer/plugin.rb
@@ -51,8 +51,11 @@ module Danger
         summary = result.fetch("totals")
         report = generate_report result
       else
-        ((git.modified_files - git.deleted_files) + git.added_files)
-          .select {|file| ((file.end_with? ".php") || (file.end_with? ".inc"))}
+
+        deleted_and_renamed_files = git.deleted_files + git.renamed_files.map { |change| change[:before] }
+
+        ((git.modified_files - deleted_and_renamed_files) + git.added_files)
+          .select { |file| ((file.end_with? ".php") || (file.end_with? ".inc")) }
           .map { |file| file.gsub("#{Dir.pwd}/", '') }
           .each do |file|
             result = run_phpcs(bin, file)


### PR DESCRIPTION
**Summary**
For renamed files, the list of filtered file names is not correctly handled, causing run_phpcs to be called on a non-existent filename. 

**Solution**
Remove any "before" renamed filenames from the modified files list. 

**Example**
```
bundler: failed to load command: danger (/opt/hostedtoolcache/Ruby/3.0.1/x64/bin/danger)
/opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/3.0.0/json/common.rb:216:in `parse': \e[31m (Danger::DSLError)
[!] Invalid `Dangerfile` file: 809: unexpected token at 'ERROR: The file "app/xxxxxxxxx.php" does not exist.

Run "phpcs --help" for usage information

'. Updating the Danger gem might fix the issue. Your Danger version: 8.2.1, latest Danger version: 8.2.3
\e[0m
 #  from Dangerfile:15
 #  -------------------------------------------
 #  php_codesniffer.standard = "PSR12"
 >  php_codesniffer.exec
 #  -------------------------------------------
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/3.0.0/json/common.rb:216:in `parse'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-php_codesniffer-0.1.7/lib/php_codesniffer/plugin.rb:101:in `run_phpcs'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-php_codesniffer-0.1.7/lib/php_codesniffer/plugin.rb:58:in `block in exec'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/helpers/array_subclass.rb:49:in `each'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/helpers/array_subclass.rb:49:in `respond_to_method'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/helpers/array_subclass.rb:19:in `method_missing'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-php_codesniffer-0.1.7/lib/php_codesniffer/plugin.rb:57:in `exec'
[!] The exception involves the following plugins:
	from Dangerfile:15:in `eval_file'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/dangerfile.rb:307:in `eval'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/dangerfile.rb:307:in `eval_file'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/dangerfile.rb:200:in `block in parse'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/dangerfile.rb:197:in `instance_eval'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/dangerfile.rb:197:in `parse'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/dangerfile.rb:283:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/danger_core/executor.rb:29:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/lib/danger/commands/runner.rb:73:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/danger-8.2.1/bin/danger:5:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/danger:23:in `load'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/danger:23:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/cli/exec.rb:63:in `load'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/cli/exec.rb:63:in `kernel_load'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/cli/exec.rb:28:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/cli.rb:494:in `exec'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/cli.rb:30:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/cli.rb:24:in `start'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/exe/bundle:49:in `block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/gems/3.0.0/gems/bundler-2.2.16/exe/bundle:37:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/bundle:23:in `load'
	from /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/bundle:23:in `<main>'
/opt/hostedtoolcache/Ruby/3.0.1/x64/lib/ruby/3.0.0/json/common.rb:216:in `parse': 809: unexpected token at 'ERROR: The file "app/xxxxxxxxx.php" does not exist. (JSON::ParserError)

Run "phpcs --help" for usage information
```
